### PR TITLE
Update to Python3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-python3.8
+FROM public.ecr.aws/sam/build-python3.9
 
 ARG mysql_gpg_key_url="https://repo.mysql.com/RPM-GPG-KEY-mysql"
 ARG mysql_gpg_key_name="RPM-GPG-KEY-mysql"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you need a ready-made, tested AWS Layer for `mysqlclient`, just use `build_ou
 
 | Python Version  |  MySQL Version | Branch to use  |
 |---|---|---|
-| 3.x  |  MySQL v8.0.x |  master |
+| 3.9  |  MySQL v8.0.x |  master |
 | 3.x  |  MySQL v5.6.x  |  mysql-5.6 |
 | 3.x | I want to build an AWS Lambda layer for a non-MySQL Python package| general-purpose |
 


### PR DESCRIPTION
This PR update Python 3.8 to Python 3.9, which is up-to-date version in AWS Lambda.

lambci/lambda Docker image does not provide 3.9 image, so I use public.ecr.aws/sam/build-python3.9 instead.