### PR TITLE
Python39 layer.zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-python3.8
+FROM public.ecr.aws/sam/build-python3.9
 
 ARG mysql_gpg_key_url="https://repo.mysql.com/RPM-GPG-KEY-mysql"
 ARG mysql_gpg_key_name="RPM-GPG-KEY-mysql"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM lambci/lambda:build-python3.8
 
-ARG mysql_gpg_key_url="https://repo.mysql.com/RPM-GPG-KEY-mysql"
-ARG mysql_gpg_key_name="RPM-GPG-KEY-mysql"
+ARG mysql_gpg_key_url="https://repo.mysql.com/RPM-GPG-KEY-mysql-2022"
+ARG mysql_gpg_key_name="RPM-GPG-KEY-mysql-2022"
 ARG mysql_repo_rpm="mysql80-community-release-el7-3.noarch.rpm"
 ARG mysql_devel_package_url="https://dev.mysql.com/get/${mysql_repo_rpm}"
 ARG mysql_devel_package="mysql-community-devel"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you need a ready-made, tested AWS Layer for `mysqlclient`, just use `build_ou
 
 | Python Version  |  MySQL Version | Branch to use  |
 |---|---|---|
-| 3.x  |  MySQL v8.0.x |  master |
+| 3.9  |  MySQL v8.0.x |  master |
 | 3.x  |  MySQL v5.6.x  |  mysql-5.6 |
 | 3.x | I want to build an AWS Lambda layer for a non-MySQL Python package| general-purpose |
 


### PR DESCRIPTION
Sorry for bothering you!

I've forgotten update layer.zip Python3.9 version.

This PR includes following PR changes.

PR #6
> Thank you very much for publishing such a nice repository!
> 
> Unfortunately, current build.sh would fail because MySQL GPG Key is updated.
> 
> This PR update MySQL GPG Key to fix the problem.

PR #7 
> This PR update Python 3.8 to Python 3.9, which is up-to-date version in AWS Lambda.
> 
> lambci/lambda Docker image does not provide 3.9 image, so I use public.ecr.aws/sam/build-python3.9 instead.
