### PR TITLE
Update MySQL GPG key.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM lambci/lambda:build-python3.8
 
-ARG mysql_gpg_key_url="https://repo.mysql.com/RPM-GPG-KEY-mysql"
-ARG mysql_gpg_key_name="RPM-GPG-KEY-mysql"
+ARG mysql_gpg_key_url="https://repo.mysql.com/RPM-GPG-KEY-mysql-2022"
+ARG mysql_gpg_key_name="RPM-GPG-KEY-mysql-2022"
 ARG mysql_repo_rpm="mysql80-community-release-el7-3.noarch.rpm"
 ARG mysql_devel_package_url="https://dev.mysql.com/get/${mysql_repo_rpm}"
 ARG mysql_devel_package="mysql-community-devel"


### PR DESCRIPTION
Current build.sh would fail because MySQL GPG Key is updated.

This PR update MySQL GPG Key to fix the problem.

(Recreated)